### PR TITLE
Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,4 +39,3 @@ jobs:
         GITHUB_TOKEN: ${{ github.token }}
       with:
         files: ${{env.GITHUB_WORKSPACE}}/artifacts/Release.zip
-        make_latest: true


### PR DESCRIPTION
Github release process already marks the "latest" release, so the workflow shouldn't override that