### PR TITLE
Header had incorrect references to some static libs.

### DIFF
--- a/DxErr/src/DXErr.h
+++ b/DxErr/src/DXErr.h
@@ -74,32 +74,32 @@
 #define STRICT
 #endif
 
-#ifdef _WIN64 // x64
+#ifdef _WIN64
 #ifdef _UNICODE
-#ifdef _DEBUG
+#ifdef _DEBUG	// x64/UNICODE/DEBUG
 #pragma comment(lib, "DXErr_x64_ud.lib")
-#else
-#pragma comment(lib, "DXErr_x64_u.lib")
+#else			// x64/UNICODE/RELEASE
+#pragma comment(lib, "DXErr_x64_ur.lib")
 #endif
 #else
-#ifdef _DEBUG
+#ifdef _DEBUG	// x64/ANSI/DEBUG
 #pragma comment(lib, "DXErr_x64_ad.lib")
-#else
-#pragma comment(lib, "DXErr_x64_a.lib")
+#else			// x64/ANSI/RELEASE
+#pragma comment(lib, "DXErr_x64_ar.lib")
 #endif
 #endif
 #else
 #ifdef _UNICODE
-#ifdef _DEBUG
+#ifdef _DEBUG	// x86/UNICODE/DEBUG
 #pragma comment(lib, "DXErr_x86_ud.lib")
-#else
-#pragma comment(lib, "DXErr_x86_u.lib")
+#else			// x86/UNICODE/RELEASE
+#pragma comment(lib, "DXErr_x86_ur.lib")
 #endif
 #else
-#ifdef _DEBUG
+#ifdef _DEBUG	// x86/ANSI/DEBUG
 #pragma comment(lib, "DXErr_x86_ad.lib")
-#else
-#pragma comment(lib, "DXErr_x86_a.lib")
+#else			// x86/ANSI/RELEASE
+#pragma comment(lib, "DXErr_x86_ar.lib")
 #endif
 #endif
 #endif

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,49 @@
-MIT License
+Microsoft Public License (MS-PL)
 
-Copyright (c) 2024 Ryan Beesley
+This license governs use of the accompanying software. If you use the
+software, you accept this license. If you do not accept the license, do not
+use the software.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+1. Definitions
+The terms "reproduce," "reproduction," "derivative works," and "distribution"
+have the same meaning here as under U.S. copyright law.
+A "contribution" is the original software, or any additions or changes to the
+software.
+A "contributor" is any person that distributes its contribution under this
+license.
+"Licensed patents" are a contributor's patent claims that read directly on its
+contribution.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+2. Grant of Rights
+(A) Copyright Grant- Subject to the terms of this license, including the
+license conditions and limitations in section 3, each contributor grants you a
+non-exclusive, worldwide, royalty-free copyright license to reproduce its
+contribution, prepare derivative works of its contribution, and distribute its
+contribution or any derivative works that you create.
+(B) Patent Grant- Subject to the terms of this license, including the license
+conditions and limitations in section 3, each contributor grants you a
+non-exclusive, worldwide, royalty-free license under its licensed patents to
+make, have made, use, sell, offer for sale, import, and/or otherwise dispose
+of its contribution in the software or derivative works of the contribution in
+the software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+3. Conditions and Limitations
+(A) No Trademark License- This license does not grant you rights to use any
+contributors' name, logo, or trademarks.
+(B) If you bring a patent claim against any contributor over patents that you
+claim are infringed by the software, your patent license from such contributor
+to the software ends automatically.
+(C) If you distribute any portion of the software, you must retain all
+copyright, patent, trademark, and attribution notices that are present in the
+software.
+(D) If you distribute any portion of the software in source code form, you may
+do so only under this license by including a complete copy of this license
+with your distribution. If you distribute any portion of the software in
+compiled or object code form, you may only do so under a license that complies
+with this license.
+(E) The software is licensed "as-is." You bear the risk of using it.
+The contributors give no express warranties, guarantees or conditions. You may
+have additional consumer rights under your local laws which this license
+cannot change. To the extent permitted under your local laws, the contributors
+exclude the implied warranties of merchantability, fitness for a particular
+purpose and non-infringement.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,32 @@
 # DXErr
-`DXErr.lib` equivalent, providing support for ANSI and Unicode messages, sourced from nitrocaster, fixed by ChiliTomatoNoodle to resolve bugs and typos, and further modified by me to provide something which works on Windows 10/11 and x86/x64, for use with the inspired ChiliTomatoNoodle C++ 3D DirectX Tutorial project with modern C++20 standards.
+
+One of the little utility libraries in the DirectX SDK is a static library for converting HRESULTs
+to text strings for debugging and diagnostics known as `DXERR.LIB`. There were once even older versions of this library, `DXERR8.LIB` and `DXERR9.LIB`, but they were removed from the DirectX SDK many years back in favor of a unified `DXERR.LIB`.
+
+However, this library was removed from Windows SDK 8.0 (see "[Where is DXERR.LIB?](http://blogs.msdn.com/b/chuckw/archive/2012/04/24/where-s-dxerr-lib.aspx)" [[Archive]](https://web.archive.org/web/20160224020327/http://blogs.msdn.com:80/b/chuckw/archive/2012/04/24/where-s-dxerr-lib.aspx)).
+
+DXERR.LIB contained the following functions (both ASCII and UNICODE):
+
+* `DXGetErrorString`
+* `DXGetErrorDescription`
+* `DXTrace`
+
+And the macros `DXTRACE_MSG`, `DXTRACE_ERR`, `DXTRACE_ERR_MSGBOX`
+
+Nitrocaster's implementation was taken from
+Chuck Walbourn's MSDN blog and modified to comply with software that uses ANSI encoding.
+
+ChiliTomatoNoodle took that implementation and introduced an updated version in [Chapter 14 of the HW3D C++ 3D DirectX Tutorial project](https://github.com/planetchili/hw3d/blob/T14-End/hw3d/dxerr.h).
+
+This is a `DXERR.LIB` modern equivalent, providing support for ANSI and Unicode messages, saved from the Microsoft trash heap by Chuck Walbourn, extracted and made to work on ANSI and Unicode by nitrocaster, fixed by ChiliTomatoNoodle to resolve bugs and typos, and further modified to provide something which works on Windows 10/11 and x86/x64, for use with the inspired ChiliTomatoNoodle C++ 3D DirectX Tutorial project using modern C++ standards.
 
 ## Usage
-To use and assuming you have added the DXErr library to the subdirectory `libs/DXErr`, add the header to your source:
+Update the `C/C++ > General > Additional Include Directories` and `Linker > General > Additional Library Directories` project properties to include this library directory. Something like `$(ProjectDir)libs\DXErr` will work for all configurations if you follow a structure where the libs directory is a subdirectory under the Project Directory.
+
+Then add the header to your source:
 
 ```C++
-#include "libs/DXErr/DXErr.h"
+#include "DXErr.h"
 ```
 
-This will link the library to the project and configure it for the coordinate of ANSI/Unicode, x86/x64, debug/release. The PDBs are include for the debug builds, but they aren't necessary to use the library.
+This will link the library to the project and configure it to automatically link to the coordinate of ANSI/Unicode, x86/x64, debug/release based on your project build. The PDBs are include for the debug builds, but they aren't necessary to use the library.


### PR DESCRIPTION
README.md updated with more details about how to use this library. Corrected LICENSE to match nitrocaster's license.